### PR TITLE
Hover provider bug fixes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 await debrickedCommand.commands(context);
                 await providers.registerHover(context);
-                await providers.registerDependencyPolicyProvider(context);
 
                 const debCommandsProvider = new DebrickedCommandsTreeDataProvider();
                 vscode.window.registerTreeDataProvider(Organization.debrickedCommand, debCommandsProvider);
@@ -64,6 +63,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 // Add file watcher for all files found from 'debricked files find'
                 await watchers.registerWatcher(context);
+                await providers.registerDependencyPolicyProvider(context); // after adding watcher and scanning we should add the policy provider
 
                 progress.report({ message: "Debricked extension is ready to use", increment: 100 - progressCount });
                 await new Promise((resolve) => setTimeout(resolve, 1000)); // added for showing the last progress info

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -37,6 +37,10 @@ class Providers {
                 context.subscriptions.push(diagnosticCollection);
 
                 const provider = new DependencyPolicyProvider(diagnosticCollection);
+                //added to activate the policy violation provider when the manifest file is already open
+                if (vscode.window.activeTextEditor?.document) {
+                    provider.checkPolicyViolation(vscode.window.activeTextEditor?.document);
+                }
 
                 context.subscriptions.push(
                     vscode.languages.registerCodeActionsProvider({ scheme: "file" }, provider, {

--- a/src/providers/manifestDependencyHoverProvider.ts
+++ b/src/providers/manifestDependencyHoverProvider.ts
@@ -20,7 +20,7 @@ export class ManifestDependencyHoverProvider implements vscode.HoverProvider {
         }
 
         const lineText = document.lineAt(position.line).text;
-        const dependencyName = this.parseDependencyName(lineText, currentManifestFile);
+        const dependencyName = this.parseDependencyName(lineText, currentManifestFile, document.getText());
 
         if (!dependencyName) {
             return null;
@@ -82,13 +82,19 @@ export class ManifestDependencyHoverProvider implements vscode.HoverProvider {
         return contents;
     }
 
-    private parseDependencyName(lineText: string, fileName: string): string | null {
+    private parseDependencyName(lineText: string, fileName: string, documentText: string): string | null {
         lineText = lineText.trim();
 
         switch (fileName) {
             case "package.json": {
+                const manifestData = JSON.parse(documentText) || {};
+                const allDependencies = {
+                    ...manifestData.dependencies,
+                    ...manifestData.devDependencies,
+                };
                 const match = commonHelper.extractValueFromStringUsingRegex(lineText, Regex.packageJson);
-                if (match) {
+
+                if (match && match in allDependencies) {
                     return match;
                 }
                 break;

--- a/src/services/scanService.ts
+++ b/src/services/scanService.ts
@@ -66,7 +66,7 @@ export class ScanService {
                         `${Organization.debrickedCli} ${cmdParams.join(" ")}`,
                         true,
                     );
-                    if (!output.includes(SecondService.repositoryBaseUrl)) {
+                    if (output.includes(SecondService.repositoryBaseUrl)) {
                         if (
                             DebrickedCommands.SCAN.flags &&
                             DebrickedCommands.SCAN.flags[2].report &&

--- a/src/services/scanService.ts
+++ b/src/services/scanService.ts
@@ -54,7 +54,7 @@ export class ScanService {
                 }
             }
 
-            vscode.window.withProgress(
+            await vscode.window.withProgress(
                 {
                     location: vscode.ProgressLocation.Window,
                     title: Organization.nameCaps,


### PR DESCRIPTION
Fixes 

- Fixed hover provider should activate only on the dependency in manifest file
- Fixed policy violation provider not triggering when manifest file is already opened
- other minor fix related to scanning